### PR TITLE
Youtube API 연결 및 APIService 작성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ xcuserdata/
 /*.gcno
 **/xcshareddata/WorkspaceSettings.xcsettings
 
+Secrets.xcconfig
+
 # End of https://www.toptal.com/developers/gitignore/api/xcode
 
 # Created by https://www.toptal.com/developers/gitignore/api/macos

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+# Youtube Clone App <!-- omit from toc -->
+
+Simple Youtube Clone App built with UIKit. It uses the Youtube API to fetch videos and display them in a list.
+
+---
+
+## Development <!-- omit from toc -->
+
+Clone this repository and open `YoutubeCloneApp.xcodeproj` with [Xcode](https://developer.apple.com/xcode/).
+
+### Setting API Keys <!-- omit from toc -->
+
+1. Make a file named `Secrets.xcconfig` in `Resources` directory below the `Secrets.example.xcconfig`.
+2. Copy all contents of `Secrets.example.xcconfig` to `Secrets.xcconfig`.
+2. Erase placeholder of the `YOUTUBE_API_KEY`.
+3. (Optional) Fill the `YOUTUBE_API_KEY` with your API key. You can get it from [Google Cloud Platform](https://console.cloud.google.com/apis/credentials).
+
+---

--- a/YoutubeCloneApp.xcodeproj/project.pbxproj
+++ b/YoutubeCloneApp.xcodeproj/project.pbxproj
@@ -36,6 +36,15 @@
 		333647312AA5B0D800C37275 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333647302AA5B0D800C37275 /* User.swift */; };
 		333647332AA5B12800C37275 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333647322AA5B12800C37275 /* Extensions.swift */; };
 		333647352AA5CBEF00C37275 /* Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333647342AA5CBEF00C37275 /* Events.swift */; };
+		333647392AA6E7E700C37275 /* YoutubeService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333647382AA6E7E700C37275 /* YoutubeService.swift */; };
+		3336473B2AA6E9B000C37275 /* YoutubeVideoListResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3336473A2AA6E9B000C37275 /* YoutubeVideoListResponseModel.swift */; };
+		3336473D2AA6EAB700C37275 /* YoutubePageInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3336473C2AA6EAB700C37275 /* YoutubePageInfoModel.swift */; };
+		333647402AA6EB0B00C37275 /* YoutubeVideoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3336473F2AA6EB0B00C37275 /* YoutubeVideoModel.swift */; };
+		333647422AA6EC8300C37275 /* YoutubeVideoThumbnailModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333647412AA6EC8300C37275 /* YoutubeVideoThumbnailModel.swift */; };
+		333647442AA6F12900C37275 /* YoutubeVideo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333647432AA6F12900C37275 /* YoutubeVideo.swift */; };
+		333647462AA70D5B00C37275 /* YoutubeChannelListResponseModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333647452AA70D5B00C37275 /* YoutubeChannelListResponseModel.swift */; };
+		333647482AA70DA500C37275 /* YoutubeChannelModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333647472AA70DA500C37275 /* YoutubeChannelModel.swift */; };
+		3336474A2AA70DD600C37275 /* YoutubeThumbnailList'Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 333647492AA70DD600C37275 /* YoutubeThumbnailList'Model.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -70,6 +79,17 @@
 		333647302AA5B0D800C37275 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		333647322AA5B12800C37275 /* Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
 		333647342AA5CBEF00C37275 /* Events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Events.swift; sourceTree = "<group>"; };
+		333647362AA6E25A00C37275 /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
+		333647372AA6E2A100C37275 /* Secrets.example.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.example.xcconfig; sourceTree = "<group>"; };
+		333647382AA6E7E700C37275 /* YoutubeService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YoutubeService.swift; sourceTree = "<group>"; };
+		3336473A2AA6E9B000C37275 /* YoutubeVideoListResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YoutubeVideoListResponseModel.swift; sourceTree = "<group>"; };
+		3336473C2AA6EAB700C37275 /* YoutubePageInfoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YoutubePageInfoModel.swift; sourceTree = "<group>"; };
+		3336473F2AA6EB0B00C37275 /* YoutubeVideoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YoutubeVideoModel.swift; sourceTree = "<group>"; };
+		333647412AA6EC8300C37275 /* YoutubeVideoThumbnailModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YoutubeVideoThumbnailModel.swift; sourceTree = "<group>"; };
+		333647432AA6F12900C37275 /* YoutubeVideo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YoutubeVideo.swift; sourceTree = "<group>"; };
+		333647452AA70D5B00C37275 /* YoutubeChannelListResponseModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YoutubeChannelListResponseModel.swift; sourceTree = "<group>"; };
+		333647472AA70DA500C37275 /* YoutubeChannelModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YoutubeChannelModel.swift; sourceTree = "<group>"; };
+		333647492AA70DD600C37275 /* YoutubeThumbnailList'Model.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "YoutubeThumbnailList'Model.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -121,6 +141,8 @@
 				333646E02AA597C900C37275 /* SceneDelegate.swift */,
 				333646DE2AA597C900C37275 /* AppDelegate.swift */,
 				333647322AA5B12800C37275 /* Extensions.swift */,
+				333647372AA6E2A100C37275 /* Secrets.example.xcconfig */,
+				333647362AA6E25A00C37275 /* Secrets.xcconfig */,
 			);
 			path = Resources;
 			sourceTree = "<group>";
@@ -176,6 +198,7 @@
 			children = (
 				3336470A2AA5AB8B00C37275 /* APIService.swift */,
 				3336470C2AA5AB9C00C37275 /* AuthService.swift */,
+				333647382AA6E7E700C37275 /* YoutubeService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -228,6 +251,7 @@
 			isa = PBXGroup;
 			children = (
 				3336472E2AA5B0D100C37275 /* UserModel.swift */,
+				3336473E2AA6EABB00C37275 /* Youtube */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -236,8 +260,23 @@
 			isa = PBXGroup;
 			children = (
 				333647302AA5B0D800C37275 /* User.swift */,
+				333647432AA6F12900C37275 /* YoutubeVideo.swift */,
 			);
 			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		3336473E2AA6EABB00C37275 /* Youtube */ = {
+			isa = PBXGroup;
+			children = (
+				3336473A2AA6E9B000C37275 /* YoutubeVideoListResponseModel.swift */,
+				3336473F2AA6EB0B00C37275 /* YoutubeVideoModel.swift */,
+				333647412AA6EC8300C37275 /* YoutubeVideoThumbnailModel.swift */,
+				333647452AA70D5B00C37275 /* YoutubeChannelListResponseModel.swift */,
+				333647472AA70DA500C37275 /* YoutubeChannelModel.swift */,
+				3336473C2AA6EAB700C37275 /* YoutubePageInfoModel.swift */,
+				333647492AA70DD600C37275 /* YoutubeThumbnailList'Model.swift */,
+			);
+			path = Youtube;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -312,25 +351,34 @@
 			files = (
 				333647212AA5AFAC00C37275 /* Publishable.swift in Sources */,
 				333647232AA5AFC300C37275 /* EventBus.swift in Sources */,
+				333647402AA6EB0B00C37275 /* YoutubeVideoModel.swift in Sources */,
+				3336473B2AA6E9B000C37275 /* YoutubeVideoListResponseModel.swift in Sources */,
+				333647462AA70D5B00C37275 /* YoutubeChannelListResponseModel.swift in Sources */,
 				333646E32AA597C900C37275 /* RootViewController.swift in Sources */,
 				333647022AA5A9F500C37275 /* SignInView.swift in Sources */,
 				333646FB2AA5A8B200C37275 /* TypedViewController.swift in Sources */,
 				333647312AA5B0D800C37275 /* User.swift in Sources */,
+				333647422AA6EC8300C37275 /* YoutubeVideoThumbnailModel.swift in Sources */,
 				333647352AA5CBEF00C37275 /* Events.swift in Sources */,
 				333647162AA5AC5B00C37275 /* DetailView.swift in Sources */,
+				3336474A2AA70DD600C37275 /* YoutubeThumbnailList'Model.swift in Sources */,
 				333646FF2AA5A9D700C37275 /* SignInViewController.swift in Sources */,
 				333646DF2AA597C900C37275 /* AppDelegate.swift in Sources */,
 				3336470D2AA5AB9C00C37275 /* AuthService.swift in Sources */,
+				333647442AA6F12900C37275 /* YoutubeVideo.swift in Sources */,
 				3336471C2AA5AD9100C37275 /* ProfileViewController.swift in Sources */,
 				3336472F2AA5B0D100C37275 /* UserModel.swift in Sources */,
 				333647292AA5AFF200C37275 /* UserDefaultsStorage.swift in Sources */,
 				3336471A2AA5AD8300C37275 /* DetailViewController.swift in Sources */,
+				3336473D2AA6EAB700C37275 /* YoutubePageInfoModel.swift in Sources */,
 				333647182AA5AC6B00C37275 /* ProfileView.swift in Sources */,
 				333647052AA5AB1900C37275 /* SignUpView.swift in Sources */,
 				3336470B2AA5AB8B00C37275 /* APIService.swift in Sources */,
 				333647082AA5AB5C00C37275 /* SignUpViewController.swift in Sources */,
 				333647102AA5ABD500C37275 /* HomeView.swift in Sources */,
 				333647262AA5AFD600C37275 /* Storage.swift in Sources */,
+				333647392AA6E7E700C37275 /* YoutubeService.swift in Sources */,
+				333647482AA70DA500C37275 /* YoutubeChannelModel.swift in Sources */,
 				333646E12AA597C900C37275 /* SceneDelegate.swift in Sources */,
 				333647332AA5B12800C37275 /* Extensions.swift in Sources */,
 				333647122AA5ABEC00C37275 /* HomeViewController.swift in Sources */,
@@ -470,6 +518,7 @@
 		};
 		333646F02AA597CA00C37275 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 333647362AA6E25A00C37275 /* Secrets.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;

--- a/YoutubeCloneApp/Controllers/SignInViewController.swift
+++ b/YoutubeCloneApp/Controllers/SignInViewController.swift
@@ -4,7 +4,7 @@ final class SignInViewController: TypedViewController<SignInView> {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        EventBus.shared.on(SignInEvent.self, by: self) { (listener, payload) in
+        EventBus.shared.on(SignInEvent.self, by: self) { listener, payload in
             print(payload.email, payload.password)
             AuthService.shared.login(
                 email: payload.email,

--- a/YoutubeCloneApp/Info.plist
+++ b/YoutubeCloneApp/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>Secrets</key>
+	<dict>
+		<key>YOUTUBE_API_KEY</key>
+		<string>$(YOUTUBE_API_KEY)</string>
+	</dict>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/YoutubeCloneApp/Models/Youtube/YoutubeChannelListResponseModel.swift
+++ b/YoutubeCloneApp/Models/Youtube/YoutubeChannelListResponseModel.swift
@@ -1,0 +1,6 @@
+struct YoutubeChannelListResponseModel: Codable {
+    let prevPageToken: String?
+    let nextPageToken: String?
+    let pageInfo: YoutubePageInfoModel
+    let items: [YoutubeChannelModel]
+}

--- a/YoutubeCloneApp/Models/Youtube/YoutubeChannelModel.swift
+++ b/YoutubeCloneApp/Models/Youtube/YoutubeChannelModel.swift
@@ -1,0 +1,11 @@
+struct YoutubeChannelModel: Codable {
+    let id: String
+    let snippet: YoutubeChannelSnippetModel
+}
+
+struct YoutubeChannelSnippetModel: Codable {
+    let title: String
+    let description: String
+    var thumbnails: YoutubeThumbnailListModel
+}
+

--- a/YoutubeCloneApp/Models/Youtube/YoutubeChannelModel.swift
+++ b/YoutubeCloneApp/Models/Youtube/YoutubeChannelModel.swift
@@ -8,4 +8,3 @@ struct YoutubeChannelSnippetModel: Codable {
     let description: String
     var thumbnails: YoutubeThumbnailListModel
 }
-

--- a/YoutubeCloneApp/Models/Youtube/YoutubePageInfoModel.swift
+++ b/YoutubeCloneApp/Models/Youtube/YoutubePageInfoModel.swift
@@ -1,0 +1,4 @@
+struct YoutubePageInfoModel: Codable {
+    let totalResults: Int
+    let resultsPerPage: Int
+}

--- a/YoutubeCloneApp/Models/Youtube/YoutubeThumbnailList'Model.swift
+++ b/YoutubeCloneApp/Models/Youtube/YoutubeThumbnailList'Model.swift
@@ -1,0 +1,6 @@
+struct YoutubeThumbnailListModel: Codable {
+    let medium: YoutubeVideoThumbnailModel?
+    let high: YoutubeVideoThumbnailModel?
+    let standard: YoutubeVideoThumbnailModel?
+    let maxres: YoutubeVideoThumbnailModel?
+}

--- a/YoutubeCloneApp/Models/Youtube/YoutubeVideoListResponseModel.swift
+++ b/YoutubeCloneApp/Models/Youtube/YoutubeVideoListResponseModel.swift
@@ -1,0 +1,6 @@
+struct YoutubeVideoListResponseModel: Codable {
+    let prevPageToken: String?
+    let nextPageToken: String?
+    let pageInfo: YoutubePageInfoModel
+    let items: [YoutubeVideoModel]
+}

--- a/YoutubeCloneApp/Models/Youtube/YoutubeVideoModel.swift
+++ b/YoutubeCloneApp/Models/Youtube/YoutubeVideoModel.swift
@@ -1,0 +1,19 @@
+struct YoutubeVideoModel: Codable {
+    let id: String
+    let snippet: YoutubeVideoSnippetModel
+}
+
+struct YoutubeVideoSnippetModel: Codable {
+    let title: String
+    let description: String
+    let channelId: String
+    let publishedAt: String
+    var thumbnails: YoutubeVideoThumbnailListModel
+}
+
+struct YoutubeVideoThumbnailListModel: Codable {
+    let medium: YoutubeVideoThumbnailModel?
+    let high: YoutubeVideoThumbnailModel?
+    let standard: YoutubeVideoThumbnailModel?
+    let maxres: YoutubeVideoThumbnailModel?
+}

--- a/YoutubeCloneApp/Models/Youtube/YoutubeVideoThumbnailModel.swift
+++ b/YoutubeCloneApp/Models/Youtube/YoutubeVideoThumbnailModel.swift
@@ -3,4 +3,3 @@ struct YoutubeVideoThumbnailModel: Codable {
     let width: Int
     let height: Int
 }
-

--- a/YoutubeCloneApp/Models/Youtube/YoutubeVideoThumbnailModel.swift
+++ b/YoutubeCloneApp/Models/Youtube/YoutubeVideoThumbnailModel.swift
@@ -1,0 +1,6 @@
+struct YoutubeVideoThumbnailModel: Codable {
+    let url: String
+    let width: Int
+    let height: Int
+}
+

--- a/YoutubeCloneApp/Resources/SceneDelegate.swift
+++ b/YoutubeCloneApp/Resources/SceneDelegate.swift
@@ -8,10 +8,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = .init(windowScene: windowScene)
         window?.makeKeyAndVisible()
 
-        let apiKey = (Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: String])?["YOUTUBE_API_KEY"] ?? ""
-        APIService.config.baseUrl = "https://www.googleapis.com/youtube/v3"
-        APIService.config.queryItems = [.init(name: "key", value: apiKey)]
-
         AuthService.shared.storage = UserDefaultsStorage.shared
         window?.rootViewController = RootViewController()
     }

--- a/YoutubeCloneApp/Resources/SceneDelegate.swift
+++ b/YoutubeCloneApp/Resources/SceneDelegate.swift
@@ -8,6 +8,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = .init(windowScene: windowScene)
         window?.makeKeyAndVisible()
 
+        let apiKey = (Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: String])?["YOUTUBE_API_KEY"] ?? ""
+        APIService.config.baseUrl = "https://www.googleapis.com/youtube/v3"
+        APIService.config.queryItems = [.init(name: "key", value: apiKey)]
+
         AuthService.shared.storage = UserDefaultsStorage.shared
         window?.rootViewController = RootViewController()
     }

--- a/YoutubeCloneApp/Resources/Secrets.example.xcconfig
+++ b/YoutubeCloneApp/Resources/Secrets.example.xcconfig
@@ -1,0 +1,1 @@
+YOUTUBE_API_KEY = "https://console.developers.google.com/"

--- a/YoutubeCloneApp/Services/APIService.swift
+++ b/YoutubeCloneApp/Services/APIService.swift
@@ -1,6 +1,91 @@
 import Foundation
 
+enum HttpMethod: String {
+    case get = "GET"
+    case post = "POST"
+}
+
+enum APIError: Error {
+    case invalidUrlError
+    case invalidResponse(statusCode: Int)
+    case unknownError(cause: Error)
+}
+
+final class APIConfig {
+    var baseUrl: String = ""
+    var queryItems: [URLQueryItem] = []
+}
+
 final class APIService {
     static var shared: APIService = .init()
     private init() {}
+
+    static let config = APIConfig()
+
+    private let decoder = JSONDecoder()
+
+    @discardableResult
+    func fetch<T: Codable>(
+        url: String,
+        method: HttpMethod = .get,
+        model: T.Type,
+        lazy: Bool = false,
+        queryItems: [URLQueryItem] = [],
+        completion: @escaping (Result<T, APIError>) -> Void
+    ) -> () -> Void {
+        func load() {
+            Task {
+                do {
+                    let url = try createUrl(string: "\(Self.config.baseUrl)\(url)", queryItems: Self.config.queryItems + queryItems)
+                    let (data, _) = try await URLSession.shared.data(for: createRequest(url: url))
+                    let model = try decoder.decode(T.self, from: data)
+                    completion(.success(model))
+                } catch {
+                    completion(.failure(.unknownError(cause: error)))
+                }
+            }
+        }
+
+        if !lazy { load() }
+        return load
+    }
+
+    func fetch<T: Codable>(
+        url: String,
+        method: HttpMethod = .get,
+        model: T.Type,
+        lazy: Bool = false,
+        queryItems: [URLQueryItem] = []
+    ) async -> Result<T, APIError> {
+        do {
+            let url = try createUrl(string: "\(Self.config.baseUrl)\(url)", queryItems: Self.config.queryItems + queryItems)
+            let (data, response) = try await URLSession.shared.data(for: createRequest(url: url))
+            if let res = response as? HTTPURLResponse, 400 ..< 600 ~= res.statusCode {
+                debugPrint(try JSONSerialization.jsonObject(with: data))
+                return .failure(.invalidResponse(statusCode: res.statusCode))
+            }
+            let model = try decoder.decode(T.self, from: data)
+            return .success(model)
+        } catch {
+            if let error = error as? APIError { return .failure(error) }
+            return .failure(.unknownError(cause: error))
+        }
+    }
+
+    private func createUrl(string: String, queryItems: [URLQueryItem]) throws -> URL {
+        guard var urlComponents = URLComponents(string: string) else { throw APIError.invalidUrlError }
+        var _queryItems = urlComponents.queryItems ?? []
+        queryItems.forEach { _queryItems.append($0) }
+        urlComponents.queryItems = _queryItems
+        guard let url = urlComponents.url else { throw APIError.invalidUrlError }
+        return url
+    }
+
+    private func createRequest(url: URL?, method: HttpMethod = .get) throws -> URLRequest {
+        guard let url else { throw APIError.invalidUrlError }
+        var request = URLRequest(url: url)
+        request.httpMethod = method.rawValue
+        request.timeoutInterval = 30
+        return request
+    }
 }

--- a/YoutubeCloneApp/Services/APIService.swift
+++ b/YoutubeCloneApp/Services/APIService.swift
@@ -11,16 +11,9 @@ enum APIError: Error {
     case unknownError(cause: Error)
 }
 
-final class APIConfig {
-    var baseUrl: String = ""
-    var queryItems: [URLQueryItem] = []
-}
-
 final class APIService {
     static var shared: APIService = .init()
     private init() {}
-
-    static let config = APIConfig()
 
     private let decoder = JSONDecoder()
 
@@ -36,7 +29,7 @@ final class APIService {
         func load() {
             Task {
                 do {
-                    let url = try createUrl(string: "\(Self.config.baseUrl)\(url)", queryItems: Self.config.queryItems + queryItems)
+                    let url = try createUrl(string: url, queryItems: queryItems)
                     let (data, _) = try await URLSession.shared.data(for: createRequest(url: url))
                     let model = try decoder.decode(T.self, from: data)
                     completion(.success(model))
@@ -58,7 +51,7 @@ final class APIService {
         queryItems: [URLQueryItem] = []
     ) async -> Result<T, APIError> {
         do {
-            let url = try createUrl(string: "\(Self.config.baseUrl)\(url)", queryItems: Self.config.queryItems + queryItems)
+            let url = try createUrl(string: url, queryItems: queryItems)
             let (data, response) = try await URLSession.shared.data(for: createRequest(url: url))
             if let res = response as? HTTPURLResponse, 400 ..< 600 ~= res.statusCode {
                 debugPrint(try JSONSerialization.jsonObject(with: data))

--- a/YoutubeCloneApp/Services/AuthService.swift
+++ b/YoutubeCloneApp/Services/AuthService.swift
@@ -3,7 +3,7 @@ import Foundation
 final class AuthService {
     static var shared: AuthService = .init()
     private init() {}
-    
+
     @Publishable private(set) var user: User?
     var isAuthenticated: Bool { user != nil }
     var storage: Storage?

--- a/YoutubeCloneApp/Services/YoutubeService.swift
+++ b/YoutubeCloneApp/Services/YoutubeService.swift
@@ -14,6 +14,9 @@ final class YoutubeService {
         didSet { completed = nextPageToken == nil && !videos.isEmpty }
     }
 
+    private var BASE_URL = "https://www.googleapis.com/youtube/v3"
+    private var API_KEY: String = (Bundle.main.object(forInfoDictionaryKey: "Secrets") as? [String: String])?["YOUTUBE_API_KEY"] ?? ""
+
     func loadVideos(errorHandler: @escaping (Error) -> Void) {
         Task {
             loading = true
@@ -44,8 +47,9 @@ final class YoutubeService {
     ) async {
         Task {
             var queryItems: [URLQueryItem] = [
+                .init(name: "key", value: API_KEY),
                 .init(name: "part", value: "snippet"),
-                .init(name: "chart", value: "mostPopular")
+                .init(name: "chart", value: "mostPopular"),
             ]
 
             if next, let nextPageToken {
@@ -53,7 +57,7 @@ final class YoutubeService {
             }
 
             let videoListResult = await APIService.shared.fetch(
-                url: "/videos",
+                url: "\(BASE_URL)/videos",
                 model: YoutubeVideoListResponseModel.self,
                 queryItems: queryItems
             )
@@ -63,16 +67,17 @@ final class YoutubeService {
             }
 
             let channelListResult = await APIService.shared.fetch(
-                url: "/channels",
+                url: "\(BASE_URL)/channels",
                 model: YoutubeChannelListResponseModel.self,
                 queryItems: [
+                    .init(name: "key", value: API_KEY),
                     .init(name: "part", value: "snippet"),
                     .init(
                         name: "id",
                         value: videoList.items
                             .map { $0.snippet.channelId }
                             .joined(separator: ",")
-                    )
+                    ),
                 ]
             )
 

--- a/YoutubeCloneApp/Services/YoutubeService.swift
+++ b/YoutubeCloneApp/Services/YoutubeService.swift
@@ -6,7 +6,6 @@ final class YoutubeService {
 
     @Publishable private(set) var videos: [YoutubeVideo] = []
     @Publishable private(set) var loading = false
-
     @Publishable private(set) var refreshing = false
     @Publishable private(set) var completed = false
 

--- a/YoutubeCloneApp/Services/YoutubeService.swift
+++ b/YoutubeCloneApp/Services/YoutubeService.swift
@@ -1,0 +1,88 @@
+final class YoutubeService {
+    static let shared: YoutubeService = .init()
+    private init() {}
+
+    private(set) var videos: [YoutubeVideo] = []
+    private(set) var loading = false
+
+    private var nextPageToken: String?
+
+    func loadVideos(errorHandler: @escaping (Error) -> Void) {
+        Task {
+            loading = true
+            let videoListResult = await APIService.shared.fetch(
+                url: "/videos",
+                model: YoutubeVideoListResponseModel.self,
+                queryItems: [
+                    .init(name: "part", value: "snippet"),
+                    .init(name: "chart", value: "mostPopular")
+                ]
+            )
+
+            guard case let .success(videoList) = videoListResult else {
+                errorHandler(videoListResult.mapError { $0 } as! Error)
+                loading = false
+                return
+            }
+
+            let channelListResult = await APIService.shared.fetch(
+                url: "/channels",
+                model: YoutubeChannelListResponseModel.self,
+                queryItems: [
+                    .init(name: "part", value: "snippet"),
+                    .init(
+                        name: "id",
+                        value: videoList.items
+                            .map { $0.snippet.channelId }
+                            .joined(separator: ",")
+                    )
+                ]
+            )
+
+            guard case let .success(channelList) = channelListResult else {
+                errorHandler(videoListResult.mapError { $0 } as! Error)
+                loading = false
+                return
+            }
+
+            let channelMap: [String: YoutubeChannelSnippetModel] = channelList.items.reduce([:]) { partialResult, channel in
+                var copied = partialResult
+                copied.updateValue(channel.snippet, forKey: channel.id)
+                return copied
+            }
+
+            videos = videoList.items.map {
+                let channel = channelMap[$0.snippet.channelId]
+
+                let videoThumbnail = YoutubeVideo.Thumbnail(
+                    url: $0.snippet.thumbnails.standard?.url ?? "",
+                    width: $0.snippet.thumbnails.standard?.width ?? 0,
+                    height: $0.snippet.thumbnails.standard?.height ?? 0
+                )
+
+                let channelThumbnail = YoutubeVideo.Thumbnail(
+                    url: channel?.thumbnails.medium?.url ?? "",
+                    width: channel?.thumbnails.medium?.width ?? 0,
+                    height: channel?.thumbnails.medium?.height ?? 0
+                )
+
+                return .init(
+                    id: $0.id,
+                    title: $0.snippet.title,
+                    description: $0.snippet.description,
+                    publishedAt: $0.snippet.publishedAt,
+                    thumbnail: videoThumbnail,
+                    channel: .init(
+                        name: channel?.title ?? "Untitled",
+                        description: channel?.description ?? "",
+                        thumbnail: channelThumbnail
+                    )
+                )
+            }
+            print(videos)
+
+            nextPageToken = videoList.nextPageToken
+            loading = false
+        }
+    }
+}

--- a/YoutubeCloneApp/ViewModels/YoutubeVideo.swift
+++ b/YoutubeCloneApp/ViewModels/YoutubeVideo.swift
@@ -1,0 +1,38 @@
+final class YoutubeVideo {
+    struct Thumbnail {
+        let url: String
+        let width: Int
+        let height: Int
+    }
+    
+    struct Channel {
+        let name: String
+        let description: String
+        let thumbnail: Thumbnail
+    }
+
+    var id: String
+    var title: String
+    var description: String
+    var publishedAt: String
+    var thumbnail: Thumbnail
+    var channel: Channel
+
+    var url: String { "https://www.youtube.com/watch?v=\(id)" }
+
+    init(
+        id: String,
+        title: String,
+        description: String,
+        publishedAt: String,
+        thumbnail: Thumbnail,
+        channel: Channel
+    ) {
+        self.id = id
+        self.title = title
+        self.description = description
+        self.publishedAt = publishedAt
+        self.thumbnail = thumbnail
+        self.channel = channel
+    }
+}


### PR DESCRIPTION
>⚠️`README.md`를 참고하여 `Secrets.xcconfig` 파일을 생성해야 합니다.

### YoutubeService API

**Publishable Property**

- `videos`: 유튜브 영상 정보 배열
- `loading`: 초기 로딩 시
- `refreshing`: 새로 고침 시
- `completed`: 모든 콘텐츠를 불러왔을 경우 (Infinite Scrolling 구현 시 활용)

```swift
/// 초기 비디오 목록을 불러옵니다. (loading 속성을 변경합니다.)
func loadVideos(errorHandler: @escaping (Error) -> Void)

/// 비디오 목록을 새로고침합니다. (refreshing 속성을 변경합니다.)
func refreshVideos(errorHandler: @escaping (Error) -> Void)

/// 다음 비디오 목록을 추가로 불러옵니다. (videos에 목록이 추가됩니다.)
func loadMoreVideos(errorHandler: @escaping (Error) -> Void)
```

---

**Example**

Publishable을 활용하여 UI를 변경합니다.

```swift
YoutubeService.shared.$videos.subscribe(by: self) { _, videos in
    print("videos", videos.new.map { $0.title })
}

YoutubeService.shared.$loading.subscribe(by: self) { _, loading in
    print("loading", loading)
}

YoutubeService.shared.$completed.subscribe(by: self) { _, completed in
    print("completed", completed)
}

YoutubeService.shared.$refreshing.subscribe(by: self) { _, refreshing in
    print("refreshing", refreshing)
}

YoutubeService.shared.loadVideos { error in
    print(error)
}

DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
    YoutubeService.shared.loadMoreVideos { error in
        print(error)
    }
}

DispatchQueue.main.asyncAfter(deadline: .now() + 4) {
    YoutubeService.shared.refreshVideos { error in
        print(error)
    }
}
```

```plaintext
-> loadVideos 호출 시 loading 플래그가 변경됩니다.
loading (old: false, new: true)
loading (old: true, new: false)
videos [A, B, C]
completed (old: false, new: false)

-> loadMoreVideos 호출 시 videos 목록이 늘어납니다.
videos [A, B, C, D, E, F]
completed (old: false, new: false)

-> refreshVideos 호출 시 videos 목록이 새로고침되고 refreshing 플래그가 변경됩니다.
refreshing (old: false, new: true)
refreshing (old: true, new: false)
videos [A, B, C]
completed (old: false, new: false)
```